### PR TITLE
1 add support for areatext paper item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /node_modules/
 /dist/*/
 /dist/*.min.js
+/dist/**/*.js
+/dist/*.d.ts
 /dist/paperjs.zip
 # Yarn
 .yarn/*

--- a/examples/test/index.html
+++ b/examples/test/index.html
@@ -31,7 +31,7 @@
     // pointText.selected = true;
 
     areaText.selected = true;
-    areaText.boundsGenerator = 'auto-height';
+    areaText.boundsGenerator = 'auto-width';
 
     // areaText.on('mousedown', function () {
     //    console.log('mouse enter');

--- a/examples/test/index.html
+++ b/examples/test/index.html
@@ -31,12 +31,12 @@
     // pointText.selected = true;
 
     areaText.selected = true;
-    areaText.boundsGenerator = 'auto-width';
+    areaText.boundsGenerator = 'auto-height';
 
-    // areaText.on('mousedown', function () {
-    //    console.log('mouse enter');
-    // });
-    console.log( areaText);
+    const areaText1 = new paper.AreaText(new paper.Rectangle(new paper.Point(100, 100), size));
+    areaText1.fillColor = 'black';
+    areaText1.content = 'Some new text here';
+    areaText1.selected = true;
 </script>
 </body>
 </html>

--- a/examples/test/index.html
+++ b/examples/test/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Test Paper JS</title>
+</head>
+<body>
+<canvas id="canvas" width="200" height="200"></canvas>
+<script type="text/javascript" src="../../dist/paper-full.js"></script>
+<script type="text/javascript">
+    const canvas = document.getElementById('canvas');
+    const scope = new paper.PaperScope();
+    const project = new scope.Project(canvas);
+    const areaText = new paper.AreaText();
+    areaText.setRectangle(new paper.Rectangle(new paper.Point(50, 30), new paper.Size(100, 100)));
+    areaText.fillColor = 'black';
+    areaText.content = 'Hello there sdfsdfsdfsdfsdf!';
+    //
+    // const pointText = new paper.PointText(new paper.Point(30, 30));
+    // pointText.fillColor = 'black';
+    // pointText.content = 'Hello point text';
+    // pointText.setPoint(new paper.Point(40, 40));
+    // pointText.selected = true;
+
+    areaText.selected = true;
+
+    console.log( areaText.justification);
+</script>
+</body>
+</html>

--- a/examples/test/index.html
+++ b/examples/test/index.html
@@ -14,11 +14,16 @@
     const canvas = document.getElementById('canvas');
     const scope = new paper.PaperScope();
     const project = new scope.Project(canvas);
-    const areaText = new paper.AreaText();
-    areaText.setRectangle(new paper.Rectangle(new paper.Point(50, 30), new paper.Size(100, 100)));
+
+    const point = new paper.Point(50, 30);
+    const size = new paper.Size(100, 100);
+
+    const areaText = new paper.AreaText(new paper.Rectangle(point, size));
+    // areaText.setRectangle();
     areaText.fillColor = 'black';
-    areaText.content = 'Hello there sdfsdfsdfsdfsdf!';
-    //
+    areaText.content = 'Hello there sdfsdfsdfsdfsdf! sdfsdfsdfsdfsdf';
+
+    // areaText.changeMode(true);
     // const pointText = new paper.PointText(new paper.Point(30, 30));
     // pointText.fillColor = 'black';
     // pointText.content = 'Hello point text';
@@ -26,8 +31,12 @@
     // pointText.selected = true;
 
     areaText.selected = true;
+    areaText.boundsGenerator = 'auto-height';
 
-    console.log( areaText.justification);
+    // areaText.on('mousedown', function () {
+    //    console.log('mouse enter');
+    // });
+    console.log( areaText);
 </script>
 </body>
 </html>

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -13,6 +13,7 @@
 var gulp = require('gulp'),
     path = require('path'),
     log = require('fancy-log'),
+    exec = require('child_process').exec,
     colors = require('ansi-colors');
 
 gulp.task('watch', function () {
@@ -22,6 +23,11 @@ gulp.task('watch', function () {
                 colors.green('File ' + event.type + ': ') +
                 colors.magenta(path.basename(event.path))
             );
+
+            exec('npm run build', function (err, stdout, stderr) {
+                console.log(stdout);
+                console.log(stderr);
+            });
         });
 });
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "gulp build",
     "dist": "gulp dist",
     "zip": "gulp zip",
+    "watch": "gulp watch",
     "docs": "gulp docs",
     "publish": "gulp publish",
     "load": "gulp load",

--- a/src/core/Base.js
+++ b/src/core/Base.js
@@ -175,7 +175,7 @@ statics: /** @lends Base */{
      *     returned or converted. `options.clone` controls whether passed
      *     objects should be cloned if they are already provided in the required
      *     type
-     * @param {Number} length the amount of elements that can be read
+     * @param {Number} amount the amount of elements that can be read
      */
     read: function(list, start, options, amount) {
         // See if it's called directly on Base, and if so, read value and return

--- a/src/core/Base.js
+++ b/src/core/Base.js
@@ -678,6 +678,10 @@ statics: /** @lends Base */{
         }
     },
 
+    insertAt(array, index, ...elementsArray) {
+        array.splice(index, 0, ...elementsArray);
+    },
+
     /**
      * Capitalizes the passed string: hello world -> Hello World
      */

--- a/src/paper.js
+++ b/src/paper.js
@@ -83,6 +83,7 @@ var paper = function(self, undefined) {
 
 /*#*/ include('text/TextItem.js');
 /*#*/ include('text/PointText.js');
+/*#*/ include('text/AreaText.js');
 
 /*#*/ include('style/Color.js');
 /*#*/ include('style/Gradient.js');

--- a/src/text/AreaText.js
+++ b/src/text/AreaText.js
@@ -380,9 +380,7 @@ var AreaText = TextItem.extend(/** @lends AreaText **/ {
     },
 
     _onDoubleClick: function () {
-        this.on('doubleclick', function (e) {
-            this._changeMode();
-        });
+        this.on('doubleclick', this._changeMode);
     },
 
     _wrap: function (ctx) {
@@ -526,6 +524,27 @@ var AreaText = TextItem.extend(/** @lends AreaText **/ {
      * @name AreaText#rectangle
      * @type Rectangle
      * @default 'new paper.Rectangle(0, 0)'
+     */
+
+
+    /**
+     * {@grouptitle Rectangle}
+     *
+     * The width of the rectangle is wrapped around
+     *
+     * @name AreaText#setWidth
+     * @function
+     * @param {Number} width the number to set the width
+     */
+
+    /**
+     * {@grouptitle Rectangle}
+     *
+     * The height of the rectangle is wrapped around
+     *
+     * @name AreaText#setHeight
+     * @function
+     * @param {Number} height the number to set the height
      */
 
     /**

--- a/src/text/AreaText.js
+++ b/src/text/AreaText.js
@@ -1,0 +1,250 @@
+/*
+ * Paper.js - The Swiss Army Knife of Vector Graphics Scripting.
+ * http://paperjs.org/
+ *
+ * Copyright (c) 2011 - 2016, Juerg Lehni & Jonathan Puckey
+ * http://scratchdisk.com/ & http://jonathanpuckey.com/
+ *
+ * Distributed under the MIT license. See LICENSE file for details.
+ *
+ * All rights reserved.
+ */
+
+/**
+ * @name AreaText
+ *
+ * @class An AreaText item represents a piece of typography in your Paper.js
+ * project which starts from a certain point and extends by the amount of
+ * characters contained in it.
+ *
+ * @extends TextItem
+ */
+
+var AreaText = TextItem.extend(/** @lends AreaText **/ {
+    _class: 'AreaText',
+
+    /**
+     * Creates an area text item
+     *
+     * @name AreaText#initialize
+     * @param {Rectangle} point the position where the text will start
+     * @return {AreaText} the newly created point text
+     *
+     */
+    /**
+     * Creates an area text item from the properties described by an object
+     * literal.
+     *
+     * @name AreaText#initialize
+     * @param {Object} object an object containing properties describing the
+     *     path's attributes
+     * @return {AreaText} the newly created point text
+     */
+    initialize: function AreaText () {
+        this._anchor = [0,0];
+        this._needsWrap = false;
+        this._rectangle = arguments[0] ? this.setRectangle(arguments[0]) : new Rectangle(0, 0);
+        this._editMode = false;
+        TextItem.apply(this, arguments);
+    },
+
+    /**
+     * Determines if the AreaText is in edit mode
+     * ( In edit mode input for the current is being active )
+     *
+     * @bean
+     * @type {Boolean}
+     */
+    getEditMode: function () {
+        return this._editMode;
+    },
+
+    /**
+     * Get current content of AreaText
+     *
+     * @bean
+     * @type {string|string|*}
+     */
+    getContent: function () {
+      return this._content;
+    },
+
+    /**
+     * Setter for content.
+     */
+    setContent: function (content) {
+        this._content = '' + content;
+        this._needsWrap = true;
+        this._changed(/*#=*/Change.CONTENT);
+    },
+
+
+    /**
+     * Justification
+     *
+     * @bean
+     * @type {String}
+     */
+    getJustification: function () {
+        return this._style.justification;
+    },
+
+    setJustification: function () {
+        this._style.justification = arguments[0];
+        this._updateAnchor();
+    },
+
+    /**
+     * The AreaText's rectangle for wrapping
+     * @bean
+     * @type {Rectangle}
+     */
+    getRectangle: function () {
+        return this._rectangle;
+    },
+
+    /**
+     * Setter for rectangle. Determines the position of the element
+     */
+    setRectangle: function () {
+        var rectangle = Rectangle.read(arguments);
+        this._rectangle = rectangle;
+
+        this.translate(rectangle.topLeft.subtract(this._matrix.getTranslation()));
+        this._updateAnchor();
+        this._needsWrap = true;
+        this._changed(/*#=*/Change.GEOMETRY);
+    },
+
+    _wrap: function (ctx) {
+        this._lines = [];
+
+        var words = this.content.split(' '),
+            line = '';
+
+        for (var i = 0; i < words.length; i++) {
+            // use metrics width to determine if the word needs
+            // to be sent on the next line
+            var textLine = line + words[i] + ' ',
+                metrics = ctx.measureText(textLine),
+                testWidth = metrics.width;
+            if (testWidth > this.rectangle.width && i > 0) {
+                this._lines.push(line);
+                line = words[i] + ' ';
+            } else {
+                line = textLine;
+            }
+        }
+
+        this._lines.push(line);
+    },
+
+    _updateAnchor: function () {
+        var justification = this._style.getJustification(),
+            rectangle = this.getRectangle(),
+            anchor = new Point(0, this._style.getFontSize());
+
+        if (justification === 'center') {
+            anchor = anchor.add([rectangle.width / 2, 0]);
+        } else if (justification === 'right') {
+            anchor = anchor.add([rectangle.width, 0]);
+        }
+
+        this._anchor = anchor;
+    },
+
+    _getAnchor: function () {
+        return this._anchor;
+    },
+
+    _draw: function (ctx, params, viewMatrix) {
+        if (!this._content) {
+            return;
+        }
+
+        this._setStyles(ctx, params, viewMatrix);
+
+        var style = this._style,
+            hasFill = style.hasFill(),
+            hasStoke = style.hasStroke(),
+            rectangle = this.rectangle,
+            anchor = this._getAnchor(),
+            leading = style.getLeading(),
+            shadowColor = ctx.shadowColor;
+
+        ctx.font = style.getFontStyle();
+        ctx.textAlign = style.getJustification();
+
+        if (this._needsWrap) {
+            this._wrap(ctx);
+            this._needsWrap = false;
+        }
+
+        var lines = this._lines;
+
+
+        for (var i = 0, l = lines.length; i < l; i++) {
+            if ((i+1) * leading > rectangle.height) {
+                return;
+            }
+
+            // See Path._draw() for explanation about ctx.shadowColor
+            ctx.shadowColor = shadowColor;
+            var line = lines[i];
+
+            if (hasFill) {
+                ctx.fillText(line, anchor.x, anchor.y);
+                ctx.shadowColor = 'rgba(0, 0, 0, 0)';
+            }
+
+            if (hasStoke) {
+                ctx.strokeText(line, anchor.x, anchor.y);
+            }
+
+            ctx.translate(0, leading);
+        }
+    },
+
+    _getBounds: function (matrix, options) {
+        var bounds = new Rectangle(
+            0, 0,
+            this.rectangle.width,
+            this.rectangle.height
+        );
+
+        return matrix ? matrix._transformBounds(bounds) : bounds;
+    },
+
+    /**
+     * {@grouptitle Rectangle}
+     *
+     * The rectangle text is wrapped around
+     *
+     * @name AreaText#rectangle
+     * @type Rectangle
+     * @default 'new paper.Rectangle(0, 0)'
+     */
+
+    /**
+     * {@grouptitle Justification}
+     *
+     * Current justification of the TextArea
+     *
+     * @name AreaText#justification
+     * @type String
+     * @values 'left', 'right', 'center'
+     * @default 'center'
+     */
+
+    /**
+     * {@grouptitle Editmode}
+     *
+     * Define the mode of AreaText (can be edit mode or not edit mode).
+     * In the edit mode the special input
+     * field should open for the editing content
+     *
+     * @name AreaText#editMode
+     * @type Boolean
+     * @default false
+     */
+});

--- a/src/util/Formatter.js
+++ b/src/util/Formatter.js
@@ -18,6 +18,7 @@
 var Formatter = Base.extend(/** @lends Formatter# */{
     /**
      * @param {Number} [precision=5] the amount of fractional digits
+     * @return {VoidFunction}
      */
     initialize: function(precision) {
         this.precision = Base.pick(precision, 5);
@@ -29,29 +30,55 @@ var Formatter = Base.extend(/** @lends Formatter# */{
      * up to the amount of fractional digits.
      *
      * @param {Number} num the number to be converted to a string
+     * @return {Number} precise number
      */
-    number: function(val) {
+    number: function(num) {
         // It would be nice to use Number#toFixed() instead, but it pads with 0,
         // unnecessarily consuming space.
         // If precision is >= 16, don't do anything at all, since that appears
         // to be the limit of the precision (it actually varies).
         return this.precision < 16
-                ? Math.round(val * this.multiplier) / this.multiplier : val;
+                ? Math.round(num * this.multiplier) / this.multiplier : num;
     },
 
+    /**
+     * Utility function to create string representation of a pair
+     * @param {Number} val1
+     * @param {Number} val2
+     * @param {String} separator
+     * @return {String} example: (1, 2, ',') => 1,2
+     */
     pair: function(val1, val2, separator) {
         return this.number(val1) + (separator || ',') + this.number(val2);
     },
 
+    /**
+     * Utility function to create string representation of a point
+     * @param {{ x: Number, y: Number }} val
+     * @param {String} separator
+     * @return {String} example: ({x:1, y: 2}, ',') => 1,2
+     */
     point: function(val, separator) {
         return this.number(val.x) + (separator || ',') + this.number(val.y);
     },
 
+    /**
+     * Utility function to create string representation of a size
+     * @param {{ width: Number, height: Number }} val
+     * @param {String} separator
+     * @return {String} example: ({width:1, height: 2}, ',') => 1,2
+     */
     size: function(val, separator) {
         return this.number(val.width) + (separator || ',')
                 + this.number(val.height);
     },
 
+    /**
+     * Utility function to create string representation of a rectangle
+     * @param {{ x: Number, y: Number, width: Number, height: Number }} val
+     * @param {String} separator
+     * @return {String} example: ({x:1, y: 2}, ',') => 1,2
+     */
     rectangle: function(val, separator) {
         return this.point(val, separator) + (separator || ',')
                 + this.size(val, separator);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -485,6 +485,11 @@ var comparators = {
                 ['content', 'point']);
     },
 
+    AreaText: function (actual, expected, message, options) {
+        compareItem(actual, expected, message, options,
+            ['content', 'rectangle', 'justification', 'editMode', 'htmlId', 'boundsGenerator', 'editElement']);
+    },
+
     SymbolItem: function(actual, expected, message, options) {
         compareItem(actual, expected, message,
                 // Cloning SymbolItems does not result in cloned

--- a/test/tests/TextItem.js
+++ b/test/tests/TextItem.js
@@ -26,3 +26,105 @@ test('PointText', function() {
         return text.hitTest(text.bounds.center) != null;
     }, true);
 });
+
+
+test('AreaText(rectangle)', function () {
+    var point = new Point(50, 30);
+    var size = new Size(100, 100);
+
+    var text = new AreaText(new Rectangle(point, size));
+
+    equals(function () {
+        return Base.equals(new Rectangle(point, size), text.rectangle);
+    }, true, 'Rectangle should equal to its initial value by default');
+
+
+    text.rectangle = new Rectangle(new Point(50, 50), size);
+
+    equals(function () {
+        return Base.equals(new Rectangle(new Point(50, 50), size), text.rectangle);
+    }, true, 'Rectangles should equal');
+
+    text.setWidth(900);
+    equals(function () {
+        return text.rectangle.width;
+    }, 900, 'Widths should equal');
+
+    text.setHeight(200);
+    equals(function () {
+        return text.rectangle.height;
+    }, 200, 'Heights should equal');
+});
+
+test('AreaText(editMode)', function () {
+    var point = new Point(50, 30);
+    var size = new Size(100, 100);
+    var text = new AreaText(new Rectangle(point, size));
+
+    // default case
+    equals(text.editMode, false, 'text.editMode should be `false` by default');
+
+    text.editMode = true;
+
+    // check the element creation
+    equals(text.editMode, true, 'text.editMode should be `true`');
+    equals(function () {
+        return !!document.body.querySelector('#' + text.htmlId);
+    }, true, 'Html element for the editing exists');
+
+
+    // check that the element changes after edit mode is back to false
+    equals(function () {
+        var editElement = document.body.querySelector('#' + text.htmlId);
+        editElement.content = '';
+        editElement.value = editElement.value + 'TEST TEXT';
+
+        text.editMode = false;
+        return text.content === 'TEST TEXT';
+    }, true, 'Html element should change the content of the text area');
+
+
+    text.editMode = false;
+
+    // area-text can have multiple lines
+    equals(function () {
+        var canvas = document.createElement('canvas');
+        canvas.width = 400;
+        canvas.height = 400;
+        text.content = 'Hello! This is a multiline text. It should contain multiple lines.';
+        text._wrap(canvas.getContext('2d'));
+        return text._lines.length;
+    }, 4, 'Should have multiple lines');
+
+
+    // emit the double click and check that the editMode has been changed
+    equals(function () {
+        var dblclickEvt = document.createEvent("MouseEvents");
+        dblclickEvt.initEvent("dblclick");
+        text.view.context.canvas.dispatchEvent(dblclickEvt);
+        return text.editMode;
+    }, true, 'Should have editMode = true after double click');
+});
+
+
+// _boundsGenerators: ['auto-height', 'auto-width', 'fixed']
+test('AreaText(boundsGenerators)', function () {
+    var point = new Point(30, 30);
+    var size = new Size(100, 100);
+    var text = new AreaText(new Rectangle(point, size));
+    var editElement = document.body.querySelector('#' + text.htmlId);
+
+    // check width
+    equals(function () {
+        text.boundsGenerator = 'fixed';
+        text.editMode = true;
+        return +editElement.parentElement.style.width.replace('px', '');
+    }, text.rectangle.width);
+
+    // check height
+    equals(function () {
+        text.boundsGenerator = 'fixed';
+        text.editMode = true;
+        return +editElement.parentElement.style.height.replace('%', '');
+    }, 100);
+});


### PR DESCRIPTION
### Description

This pull requests add new feature functionality of `AreaText` to the `paper.js` library

### Checklist
- [x] The ability to switch between two modes `editing` and `normal` for modifying of the text content
- [x] Three main modes of the `AreaText` item, `auto-width`, `auto-height` and `fixed`, each of those influence differently on the content and the bounds rectangle of the item
- [x] Justification of the text
 
#### Related issues

- Relates to  https://github.com/paperjs/paper.js/issues/741

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->



<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)
